### PR TITLE
Execute install script relative to directory where script was invoked

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+# Execute script relative to folder where color pallet exists
+DIR=${BASH_SOURCE%/*}/
+
 # Color pallet config file
-FILE=challenger-deep.dconf
+FILE=$DIR"challenger-deep.dconf"
 
 # dconf path for gnome-terminal
 TERM_CONFIG="/org/gnome/terminal/legacy/"


### PR DESCRIPTION
Resolves an issue with the remote install script where it would not find the color pallet file due
to the script being run from a different directory.